### PR TITLE
bugfix/WPS-6226-PatchStack-Vulnerability-Issues

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,0 +1,3 @@
+pull_requests
+script
+docs

--- a/public/class-event-tickets-manager-for-woocommerce-public.php
+++ b/public/class-event-tickets-manager-for-woocommerce-public.php
@@ -2792,19 +2792,47 @@ class Event_Tickets_Manager_For_Woocommerce_Public {
 	 */
 	public function wps_user_type_ajax_callbck() {
 		check_ajax_referer( 'wps-etmfw-verify-public-nonce', 'wps_nonce' );
-		$wps_product_id = isset( $_REQUEST['event_product_id'] ) ? sanitize_text_field( wp_unslash( $_REQUEST['event_product_id'] ) ) : '';
+		$wps_product_id = isset( $_REQUEST['event_product_id'] ) ? absint( $_REQUEST['event_product_id'] ) : 0;
+
+		if ( ! $wps_product_id ) {
+			wp_send_json_error( array( 'message' => 'Invalid product.' ) );
+		}
+
 		$wps_etmfw_product_array = get_post_meta( $wps_product_id, 'wps_etmfw_product_array', true );
+
+		// Validate submitted price and label against the product's configured user types.
+		$user_type_data = isset( $wps_etmfw_product_array['wps_etmfw_field_user_type_price_data'] )
+			? $wps_etmfw_product_array['wps_etmfw_field_user_type_price_data']
+			: array();
+
+		$product_price_on_user_select = isset( $_REQUEST['user_type_value_data'] ) ? sanitize_text_field( wp_unslash( $_REQUEST['user_type_value_data'] ) ) : '';
+		$wps_product_type_name = isset( $_REQUEST['user_type_name_data'] ) ? sanitize_text_field( wp_unslash( $_REQUEST['user_type_name_data'] ) ) : '';
+
+		if ( ! empty( $user_type_data ) && is_array( $user_type_data ) ) {
+			$is_valid_selection = false;
+			foreach ( $user_type_data as $type ) {
+				if ( isset( $type['label'], $type['price'] )
+					&& $type['label'] === $wps_product_type_name
+					&& (string) $type['price'] === (string) $product_price_on_user_select ) {
+					$is_valid_selection = true;
+					break;
+				}
+			}
+			if ( ! $is_valid_selection ) {
+				wp_send_json_error( array( 'message' => 'Invalid user type selection.' ) );
+			}
+		}
+
 		$wps_base_price_condition = isset( $wps_etmfw_product_array['wps_etmfw_field_user_type_price_data_baseprice'] ) && ! empty( $wps_etmfw_product_array['wps_etmfw_field_user_type_price_data_baseprice'] ) ? $wps_etmfw_product_array['wps_etmfw_field_user_type_price_data_baseprice'] : array();
 
 		if ( 'base_price' == $wps_base_price_condition ) {
 			$wps_total_price = get_option( 'wps_total_increased_value' );
-
 		} elseif ( 'not_base_price' == $wps_base_price_condition ) {
+			$wps_total_price = 0;
+		} else {
 			$wps_total_price = 0;
 		}
 
-		$product_price_on_user_select = isset( $_REQUEST['user_type_value_data'] ) ? sanitize_text_field( wp_unslash( $_REQUEST['user_type_value_data'] ) ) : '';
-		$wps_product_type_name = isset( $_REQUEST['user_type_name_data'] ) ? sanitize_text_field( wp_unslash( $_REQUEST['user_type_name_data'] ) ) : '';
 		$final_price = ( $product_price_on_user_select + $wps_total_price );
 		$response = wc_price( $final_price );
 		echo wp_json_encode( $response );

--- a/public/src/js/event-tickets-manager-for-woocommerce-public.js
+++ b/public/src/js/event-tickets-manager-for-woocommerce-public.js
@@ -127,14 +127,14 @@
 	
 		});
 
-		jQuery(document).on('click', '.wps-etmfw-user-type-qty .plus, .wps-etmfw-user-type-qty .minus', function() {
+		jQuery(document).on('click', '.wps-etmfw-user-type-qty .wps-etmfw-plus, .wps-etmfw-user-type-qty .wps-etmfw-minus', function() {
 			var $wrapper = jQuery(this).closest('.wps-etmfw-user-type-qty');
 			var $input = $wrapper.find('input.qty');
 			var current = parseInt($input.val(), 10);
 			if (isNaN(current)) {
 				current = 0;
 			}
-			if (jQuery(this).hasClass('plus')) {
+			if (jQuery(this).hasClass('wps-etmfw-plus')) {
 				$input.val(current + 1).trigger('change');
 			} else {
 				$input.val(Math.max(0, current - 1)).trigger('change');

--- a/public/src/scss/event-tickets-manager-for-woocommerce-public.css
+++ b/public/src/scss/event-tickets-manager-for-woocommerce-public.css
@@ -305,8 +305,8 @@ img.wps_resend_image {
   text-align: center;
 }
 
-.wps-etmfw-user-type-qty .plus,
-.wps-etmfw-user-type-qty .minus {
+.wps-etmfw-user-type-qty .wps-etmfw-plus,
+.wps-etmfw-user-type-qty .wps-etmfw-minus {
   background: var(--wps-etmfw-user-type-accent);
   border: 1px solid var(--wps-etmfw-user-type-accent);
   border-radius: 8px;
@@ -315,8 +315,8 @@ img.wps_resend_image {
   transition: transform 0.15s ease, opacity 0.15s ease;
 }
 
-.wps-etmfw-user-type-qty .plus:hover,
-.wps-etmfw-user-type-qty .minus:hover {
+.wps-etmfw-user-type-qty .wps-etmfw-plus:hover,
+.wps-etmfw-user-type-qty .wps-etmfw-minus:hover {
   opacity: 0.9;
   transform: translateY(-1px);
 }

--- a/templates/frontend/event-tickets-manager-for-woocommerce-before-atc-html.php
+++ b/templates/frontend/event-tickets-manager-for-woocommerce-before-atc-html.php
@@ -71,10 +71,10 @@ if ( in_array( $wps_plugin, $wps_plugin_list ) ) {
 				<div class="wps_etmfw_user_type_row">
 					<div class="wps_etmfw_user_type_name"><?php echo esc_html( $value['label'] ); ?></div>
 					<div class="wps_etmfw_user_type_price"><?php echo wp_kses_post( wc_price( $value['price'] ) ); ?></div>
-					<div class="wps-etmfw-user-type-qty quantity">
-						<button type="button" class="minus">-</button>
+					<div class="wps-etmfw-user-type-qty">
+						<button type="button" class="wps-etmfw-minus">-</button>
 						<input type="number" class="qty" min="0" step="1" inputmode="numeric" name="wps_etmfw_user_type_qty[<?php echo esc_attr( $key ); ?>]" value="0">
-						<button type="button" class="plus">+</button>
+						<button type="button" class="wps-etmfw-plus">+</button>
 					</div>
 				</div>
 			<?php } ?>


### PR DESCRIPTION
## Task Link
WPS-6226

## Summary
Fixed two PatchStack-reported security vulnerabilities in the user type pricing feature:
- **Price manipulation via AJAX** — The `wps_user_type_ajax_callbck` handler now validates submitted price and label values server-side against the product's configured user type data, preventing clients from injecting arbitrary prices.
- **Generic CSS class hijacking** — Button classes `.plus` / `.minus` renamed to plugin-scoped `.wps-etmfw-plus` / `.wps-etmfw-minus` to avoid collision with WooCommerce core or third-party plugins.

## Changes Made
- `public/class-event-tickets-manager-for-woocommerce-public.php` — Use `absint()` for product ID; early exit on invalid ID; validate submitted user type label+price against product meta before processing; `else` branch to initialise `$wps_total_price`
- `templates/frontend/event-tickets-manager-for-woocommerce-before-atc-html.php` — Rename button classes to `wps-etmfw-plus` / `wps-etmfw-minus`
- `public/src/js/event-tickets-manager-for-woocommerce-public.js` — Update click handler selectors to match renamed classes
- `public/src/scss/event-tickets-manager-for-woocommerce-public.css` — Update CSS rules to match renamed classes

## Testing
- Tested locally: Yes
- Edge cases covered:
  - Arbitrary price submitted via AJAX → rejected with JSON error
  - Mismatched label/price pair → rejected
  - Missing or empty user type data in product meta → validation skipped safely
  - Invalid / zero product ID → rejected early
  - Plus/minus buttons still function correctly after class rename

## Screenshots / Demo (if applicable)
N/A — security hardening, no visible UI change

## Checklist
- [x] Code reviewed by self
- [x] No unnecessary code
- [x] Proper naming conventions
