### PR TITLE
Add filters for user type multi-add functionality and render seat map action

### DIFF
--- a/public/class-event-tickets-manager-for-woocommerce-public.php
+++ b/public/class-event-tickets-manager-for-woocommerce-public.php
@@ -3016,6 +3016,10 @@ class Event_Tickets_Manager_For_Woocommerce_Public {
 	 * @return bool
 	 */
 	public function wps_etmfw_validate_user_type_quantities( $passed, $product_id, $quantity ) {
+		if ( apply_filters( 'wps_etmfw_skip_user_type_multi_add', false, $product_id ) ) {
+			return $passed;
+		}
+
 		if ( empty( $_POST['wps_etwmfw_atc_nonce'] ) || ! wp_verify_nonce( sanitize_text_field( wp_unslash( $_POST['wps_etwmfw_atc_nonce'] ) ), 'wps_etwmfw_atc_nonce' ) ) {
 			return $passed;
 		}
@@ -3051,6 +3055,10 @@ class Event_Tickets_Manager_For_Woocommerce_Public {
 	 * @return int
 	 */
 	public function wps_etmfw_set_user_type_total_quantity( $quantity, $product_id ) {
+		if ( apply_filters( 'wps_etmfw_skip_user_type_multi_add', false, $product_id ) ) {
+			return $quantity;
+		}
+
 		if ( empty( $_POST['wps_etwmfw_atc_nonce'] ) || ! wp_verify_nonce( sanitize_text_field( wp_unslash( $_POST['wps_etwmfw_atc_nonce'] ) ), 'wps_etwmfw_atc_nonce' ) ) {
 			return $quantity;
 		}
@@ -3085,6 +3093,10 @@ class Event_Tickets_Manager_For_Woocommerce_Public {
 	 * @return void
 	 */
 	public function wps_etmfw_add_user_type_items_on_add_to_cart( $cart_item_key, $product_id, $quantity, $variation_id, $variation, $cart_item_data ) {
+		if ( apply_filters( 'wps_etmfw_skip_user_type_multi_add', false, $product_id ) ) {
+			return;
+		}
+
 		if ( empty( $_POST['wps_etwmfw_atc_nonce'] ) || ! wp_verify_nonce( sanitize_text_field( wp_unslash( $_POST['wps_etwmfw_atc_nonce'] ) ), 'wps_etwmfw_atc_nonce' ) ) {
 			return;
 		}

--- a/templates/frontend/event-tickets-manager-for-woocommerce-before-atc-html.php
+++ b/templates/frontend/event-tickets-manager-for-woocommerce-before-atc-html.php
@@ -60,7 +60,7 @@ if ( in_array( $wps_plugin, $wps_plugin_list ) ) {
 	$map_api_key = get_option( 'wps_etmfw_google_maps_api_key', '' );
 
 	$wps_etmfw_field_user_type_price_data = isset( $wps_etmfw_product_array['wps_etmfw_field_user_type_price_data'] ) && ! empty( $wps_etmfw_product_array['wps_etmfw_field_user_type_price_data'] ) ? $wps_etmfw_product_array['wps_etmfw_field_user_type_price_data'] : array();
-	if ( ! empty( $wps_etmfw_field_user_type_price_data ) && is_array( $wps_etmfw_field_user_type_price_data ) ) {
+	if ( ! empty( $wps_etmfw_field_user_type_price_data ) && is_array( $wps_etmfw_field_user_type_price_data ) && apply_filters( 'wps_etmfw_show_ticket_type_qty_block', true, $product_id ) ) {
 		$product = wc_get_product( $product_id );
 		$current_product_price = 0;
 		?>
@@ -86,6 +86,7 @@ if ( in_array( $wps_plugin, $wps_plugin_list ) ) {
 		</p>
 		<?php
 	}
+	do_action( 'wps_etmfw_render_seat_map', $product_id, $wps_etmfw_field_user_type_price_data );
 	?>
 	<div class="wps_etmfw_addition_info_section">
 		<?php


### PR DESCRIPTION
## Task Link
WPS-7361

## Summary
Adds two backward-compatible extension points (one filter to hide the existing ticket-type qty stepper, one action to render a seat map in its place; one filter to opt out of the per-ticket-type cart split) so the Pro plugin's companion PR can implement Dynamic Seat Selection on the product page without forking Free's existing add-to-cart logic. No behavior changes when Pro is inactive or a product has no seat map.

## Claude Usage
- Used: Yes
- Purpose: Implement the Free-plugin extension points required by the Pro-only Dynamic Seat Selection feature (WPS-7361), per a plan researched and approved earlier in the session.
- Output generated: The two file changes listed below (filter/action additions only, no new files).
- What was manually verified/modified: Not yet — pending manual QA (see Testing).

## Changes Made
- public/class-event-tickets-manager-for-woocommerce-public.php: added `wps_etmfw_skip_user_type_multi_add` filter guard (default `false`) to the three methods that split add-to-cart by ticket type.
- templates/frontend/event-tickets-manager-for-woocommerce-before-atc-html.php: wrapped the "Choose Ticket Type" block in `wps_etmfw_show_ticket_type_qty_block` filter (default `true`), added `wps_etmfw_render_seat_map` action after it.

## Testing
- Tested locally: No — only static syntax checks (`php -l`) run so far. Needs manual verification in a real WooCommerce store: existing ticket-type flow unaffected with Pro inactive/active-but-non-seat-product, add-to-cart splitting still correct.
- Edge cases covered: New filters default to no-op values, so behavior is unchanged for every existing product unless Pro explicitly opts in.

## Screenshots / Demo (if applicable)
N/A — no visual change for existing products; new UI lives entirely in the Pro plugin.

## Checklist
- [x] Code reviewed by self
- [x] No unnecessary code
- [x] Proper naming conventions
